### PR TITLE
fixes #6491 - fail pulp node installation when freeipa present

### DIFF
--- a/lib/puppet/parser/functions/validate_pulp.rb
+++ b/lib/puppet/parser/functions/validate_pulp.rb
@@ -16,6 +16,10 @@ DOC
             "the pulp node can't be installed on a machine with Katello master"
       end
 
+      if system("(rpm -q ipa-server || rpm -q freeipa-server) &>/dev/null")
+        raise Puppet::ParseError,
+            "the pulp node can't be installed on a machine with IPA"
+      end
 
       unless system("subscription-manager identity | grep identity")
         raise Puppet::ParseError,


### PR DESCRIPTION
If you try to install a pulp node on a machine that has FreeIPA server
installed, we'll wipe out the httpd configuration. This prevents pulp
from being installed in that case.
