### PR TITLE
Fixes #11751 - validate_file_exists tells you which file is missing

### DIFF
--- a/lib/puppet/parser/functions/validate_file_exists.rb
+++ b/lib/puppet/parser/functions/validate_file_exists.rb
@@ -7,13 +7,13 @@ This function can work only when running puppet apply.
 # TODO:
 Find a way how to skip it for puppetmaster scenario.
 DOC
-  ) do |args|
+  ) do |files|
 
-    args.each do |arg|
-      raise Puppet::ParseError, "does not exist" unless File.exist?(arg)
+    files.each do |file|
+      raise Puppet::ParseError, "#{file} does not exist" unless File.exist?(file)
     end
 
-    return true
+    true
   end
 
 end

--- a/spec/functions/validate_file_exists_spec.rb
+++ b/spec/functions/validate_file_exists_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
+
+describe 'validate_file_exists' do
+  it { should run.with_params('foo_doesnt_exist').and_raise_error(Puppet::ParseError) }
+  it { should run.with_params('foo_doesnt_exist').and_raise_error(/foo_doesnt_exist does not exist/) }
+end


### PR DESCRIPTION
When validate_file_exists is applied upon the cert files and one is
missing, the installer should tell you which one is it.